### PR TITLE
RefreshToken과 User의 관계 변경

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,8 +1,6 @@
 import {
   Controller,
   Get,
-  HttpCode,
-  Redirect,
   Req,
   Res,
   UnauthorizedException,

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -107,6 +107,7 @@ export class AuthService {
       user: user,
       expires: new Date(Date.now() + this.refreshExpireTime),
     });
+    refreshTokenEntity.user = user;
 
     await this.refreshTokenRepository.save(refreshTokenEntity);
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,6 +1,5 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import * as OpenID from 'openid';
-import axios from 'axios';
 import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';

--- a/src/auth/entities/refreshtoken.entity.ts
+++ b/src/auth/entities/refreshtoken.entity.ts
@@ -3,9 +3,8 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
-  ManyToOne,
   CreateDateColumn,
-  UpdateDateColumn,
+  OneToOne,
 } from 'typeorm';
 
 @Entity()
@@ -16,7 +15,7 @@ export class RefreshToken {
   @Column('text')
   token: string;
 
-  @ManyToOne(() => User, (user) => user.refreshtokens)
+  @OneToOne(() => User, (user) => user.refreshtoken)
   user: User;
 
   @CreateDateColumn()

--- a/src/auth/entities/refreshtoken.entity.ts
+++ b/src/auth/entities/refreshtoken.entity.ts
@@ -5,6 +5,7 @@ import {
   Column,
   CreateDateColumn,
   OneToOne,
+  JoinColumn,
 } from 'typeorm';
 
 @Entity()
@@ -15,15 +16,19 @@ export class RefreshToken {
   @Column('text')
   token: string;
 
-  @OneToOne(() => User, (user) => user.refreshtoken)
-  user: User;
-
   @CreateDateColumn()
   createdAt: Date;
-
+  
   @Column({ default: false })
   isRevoked: boolean;
-
+  
   @Column({ type: 'timestamp' })
   expires: Date;
+
+  @Column()
+  user_id: number;
+
+  @OneToOne(() => User, (user) => user.refreshtoken)
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  user: User;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -8,6 +8,7 @@ import {
   Entity,
   ManyToMany,
   OneToMany,
+  OneToOne,
   PrimaryGeneratedColumn,
 } from 'typeorm';
 
@@ -34,6 +35,6 @@ export class User {
   @OneToMany(() => Todo, (todo) => todo.user)
   todos: Todo[];
 
-  @OneToMany(() => RefreshToken, (refreshToken) => refreshToken.user)
-  refreshtokens: RefreshToken[];
+  @OneToOne(() => RefreshToken, (refreshToken) => refreshToken.user)
+  refreshtoken: RefreshToken;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -6,6 +6,7 @@ import { Todo } from 'src/todo/entities/todo.entity';
 import {
   Column,
   Entity,
+  JoinColumn,
   ManyToMany,
   OneToMany,
   OneToOne,
@@ -36,5 +37,5 @@ export class User {
   todos: Todo[];
 
   @OneToOne(() => RefreshToken, (refreshToken) => refreshToken.user)
-  refreshtoken: RefreshToken;
+  refreshtoken: RefreshToken | null;
 }

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -1,12 +1,10 @@
 import { Expose } from 'class-transformer';
-import { Achievement } from 'src/achievement/entities/achievement.entity';
 import { RefreshToken } from 'src/auth/entities/refreshtoken.entity';
 import { Game } from 'src/game/entities/game.entity';
 import { Todo } from 'src/todo/entities/todo.entity';
 import {
   Column,
   Entity,
-  JoinColumn,
   ManyToMany,
   OneToMany,
   OneToOne,
@@ -37,5 +35,5 @@ export class User {
   todos: Todo[];
 
   @OneToOne(() => RefreshToken, (refreshToken) => refreshToken.user)
-  refreshtoken: RefreshToken | null;
+  refreshtoken: RefreshToken;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -1,14 +1,8 @@
 import {
   Controller,
   Get,
-  Post,
-  Body,
-  Query,
-  Req,
   UseGuards,
-  UnauthorizedException,
   NotFoundException,
-  HttpCode,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { AuthGuard } from 'src/auth/auth.guard';

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,11 +1,9 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
-import { CreateUserDto } from './dto/create-user.dto';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { Repository } from 'typeorm';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
-import { plainToInstance } from 'class-transformer';
 
 @Injectable()
 export class UserService {
@@ -14,14 +12,6 @@ export class UserService {
     private readonly userRepository: Repository<User>,
     private readonly configService: ConfigService,
   ) {}
-
-  // async create(createUserDto: CreateUserDto): Promise<User> {
-  //   const { steamid } = createUserDto
-  //   const userInfo = await this.getUserInfo(steamid);
-  //   const user = this.userRepository.create(userInfo);
-  //   await this.userRepository.save(user);
-  //   return user;
-  // }
 
   async getUserInfo(steamid: string): Promise<User> {
     /** db에 있으면 바로 반환 */


### PR DESCRIPTION
## 📍 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->
- 리프레시 토큰과 유저의 관계가 1:1이 되도록 했습니다.
- 필요없는 import 삭제

## 📍 구현 결과 (선택)

<!-- 구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

## 📍 기타 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이나 주의사항, 알림사항 등이 있다면 작성해주세요. -->
1:1 이지만 리프레시 토큰만 유저 ID를 저장? 참조? 합니다

## 📍 레퍼런스

<!-- 참고한 부분이 있다면 링크로 알려주세요 -->