### PR TITLE
node:lts-alpine 이미지 사용하여 도커 이미지 크기 줄이기

### DIFF
--- a/.github/workflows/docker-aws-deploy.yml
+++ b/.github/workflows/docker-aws-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         context: .
         push: true
-        tags: gjeodnd12165/steam-todo:latest
+        tags: gjeodnd12165/steam-todo:lts-alpine
     
     - name: Install jq
       run: sudo apt-get install jq -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:lts-alpine
 
 WORKDIR /usr/src/app
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM node
+FROM node:lts-alpine
 
 WORKDIR /usr/src/app
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   nestjs_api:
-    image: gjeodnd12165/steam-todo:latest
+    image: gjeodnd12165/steam-todo:lts-alpine
     platform: linux/amd64
     ports:
       - '80:3000'


### PR DESCRIPTION
## 📍 작업 내용

<!-- 이번 PR에서 작업한 내용을 간략히 설명해주세요. -->

alpine 이미지를 베이스로 사용하여 배포 이미지의 크기를 1.33GB에서 379MB로 약 28% 가량으로 줄였습니다.

이로인해 main 브랜치의 배포 시간이 줄어들기를 기대합니다.

## 📍 구현 결과 (선택)

<!-- 구현한 기능이 보이는 스크린샷을 업로드해주세요. -->

![image](https://github.com/user-attachments/assets/4cf56153-d37e-4315-bee2-dfa3f8463098)


## 📍 기타 사항

<!-- 리뷰어가 특별히 봐주었으면 하는 부분이나 주의사항, 알림사항 등이 있다면 작성해주세요. -->

## 📍 레퍼런스

<!-- 참고한 부분이 있다면 링크로 알려주세요 -->